### PR TITLE
For work also with \\ domains

### DIFF
--- a/lib/single_auth/application_controller_patch.rb
+++ b/lib/single_auth/application_controller_patch.rb
@@ -43,7 +43,7 @@ module SingleAuth
 
 
       def try_login_by_remote_env(remote_username)
-        remote_username = remote_username.to_s.split('@')[0]
+        remote_username = remote_username.to_s.split('\\')[1].split("@")[0]
         user = User.active.find_by_login remote_username
         if user.nil?
           user = add_user_by_ldap_info(remote_username)


### PR DESCRIPTION
Anyway  the line remote_username = remote_username.to_s.split('@')[0] is not included in distribution version 2.0.1
